### PR TITLE
Tell the wait method to wait for a deliver frame

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqplib==1.0.2
+amqp==2.3.2
 lockfile>=0.9.1,<0.13
 python-daemon>=2.1.2,<3.9
 configparser>=3.5,<4.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(p.join(p.dirname(__file__), 'requirements-dev.txt'), 'r') as reqs:
 
 setup(
     name='sparkplug',
-    version='1.9-dev',
+    version='1.9.1',
     author='Owen Jacobson',
     author_email='owen.jacobson@grimoire.ca',
     url='http://alchemy.grimoire.ca/python/sites/sparkplug/',

--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -24,7 +24,7 @@ which is equivalent to::
     password = guest
     # If set, forces the use of SSL to connect to the broker.
     ssl = False
-    
+
 Sparkplug operates by starting a connection, then applying all other
 configuration directives to it (to set up queues_, exchanges_, bindings_,
 and consumers_), then waiting for messages to be delivered.
@@ -37,11 +37,11 @@ and consumers_), then waiting for messages to be delivered.
 
 from __future__ import with_statement
 
+import amqp
 import time
 import socket
 from sparkplug.config.types import convert, parse_bool
 from sparkplug.logutils import LazyLogger
-from amqplib import client_0_8 as amqp
 
 _log = LazyLogger(__name__)
 

--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -42,6 +42,7 @@ import time
 import socket
 from sparkplug.config.types import convert, parse_bool
 from sparkplug.logutils import LazyLogger
+from amqp import spec
 
 _log = LazyLogger(__name__)
 
@@ -52,7 +53,7 @@ class AMQPConnector(object):
         self.connection_args = dict(kwargs)
         convert(self.connection_args, 'ssl', parse_bool)
         self.channel_configurer = channel_configurer
-    
+
     def run_channel(self, channel):
         _log.debug("Configuring channel elements.")
         self.channel_configurer.start(channel)
@@ -62,12 +63,12 @@ class AMQPConnector(object):
             _log.debug("Tearing down connection.")
             self.channel_configurer.stop(channel)
             raise
-    
+
     def pump(self, channel):
         while True:
             _log.debug("Waiting for a message.")
-            channel.wait()
-    
+            channel.wait(spec.Basic.Deliver)
+
     def run(self):
         while True:
             try:


### PR DESCRIPTION
The new library's wait method needs to take a method to wait on. Since we're running a consumer app we need to wait on the deliver method.